### PR TITLE
send bluesky_comments_post from frontmatter to template

### DIFF
--- a/nxc/nxc.py
+++ b/nxc/nxc.py
@@ -308,7 +308,10 @@ def build_site(args):
                 # render and output HTML (empty edit_url on README and Sidebar pages)
                 file_id = hashlib.md5(Path(file).stem.lower().encode()).hexdigest()
                 markdown_body = markdown_convert(markdown_text, rootdir, args[0].input, file_id, websiteroot)
-                html = render_template('page.html', **get_page_context(Path(file), markdown_body, wiki_pagelinks, config))
+                page_context = get_page_context(Path(file), markdown_body, wiki_pagelinks, config)
+                # add bluesky_comments from front matter or use empty string
+                page_context['bluesky_comments_post'] = front_matter.get('bluesky_comments_post', '')
+                html = render_template('page.html', **page_context)
                 (Path(dir_output+clean_filepath).with_suffix(".html")).write_text(html)
                 
                 # get commit message and time


### PR DESCRIPTION
@band, I think this would work to send the Bluesky post URL from the YAML frontmatter to the template. I haven't edited `page.html` yet, but it would check to see if `bluesky_comment_post` is not empty, and if not, it would include the comment block, and init with the post URL.

I have not tested this code yet.

Not yet implemented:

- syntax check that `bluesky_comment_post` is a URL (nice to have, but can ship without it)
- modifying documentation